### PR TITLE
Auch die Inzidenz der Bundesländer mit nur einer Nachkommastelle anzeigen

### DIFF
--- a/incidence.js
+++ b/incidence.js
@@ -441,7 +441,7 @@ async function getData(useStaticCoordsIndex = false) {
                 areaCases: parseFloat(attr.cases.toFixed(1)),
             },
             state: {
-                incidence: statesData.incidence,
+                incidence: parseFloat(statesData.incidence.toFixed(1)),
                 name: BUNDESLAENDER_SHORT[attr.BL],
                 cases: statesData.cases,
                 dailyCases: -1


### PR DESCRIPTION
Ansonsten kann es sein, dass das Widget nicht korrekt dargestellt wird. 
In Niedersachsen wurde eine Inzidenz von 88,258 angezeigt.