### PR TITLE
DunkelDunkelRot bei Inzidenz > 200 eingefügt

### DIFF
--- a/incidence.js
+++ b/incidence.js
@@ -38,10 +38,12 @@ const apiUrlStates = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/
 const apiUrlNewCases = 'https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_COVID19/FeatureServer/0/query?f=json&where=NeuerFall%20IN(1%2C%20-1)&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&outStatistics=%5B%7B%22statisticType%22%3A%22sum%22%2C%22onStatisticField%22%3A%22AnzahlFall%22%2C%22outStatisticFieldName%22%3A%22value%22%7D%5D&resultType=standard&cacheHint=true'
 const apiRUrl = `https://www.rki.de/DE/Content/InfAZ/N/Neuartiges_Coronavirus/Projekte_RKI/Nowcasting_Zahlen_csv.csv?__blob=publicationFile`
 
+const LIMIT_DARKDARKRED = 200
 const LIMIT_DARKRED = 100
 const LIMIT_RED = 50
 const LIMIT_ORANGE = 35
 const LIMIT_YELLOW = 25
+const LIMIT_DARKDARKRED_COLOR = new Color('490c00')
 const LIMIT_DARKRED_COLOR = new Color('a1232b')
 const LIMIT_RED_COLOR = new Color('f6000f')
 const LIMIT_ORANGE_COLOR = new Color('ff7927')
@@ -567,7 +569,9 @@ async function getRValue() {
 
 function getIncidenceColor(incidence) {
     let color = LIMIT_GREEN_COLOR
-    if (incidence >= LIMIT_DARKRED) {
+    if (incidence > LIMIT_DARKDARKRED) {
+        color = LIMIT_DARKDARKRED_COLOR
+    } else if (incidence >= LIMIT_DARKRED) {
         color = LIMIT_DARKRED_COLOR
     } else if (incidence >= LIMIT_RED) {
         color = LIMIT_RED_COLOR

--- a/incidence.js
+++ b/incidence.js
@@ -1,5 +1,8 @@
 // Variables used by Scriptable.
 // These must be at the very top of the file. Do not edit.
+// icon-color: yellow; icon-glyph: file-medical-alt;
+// Variables used by Scriptable.
+// These must be at the very top of the file. Do not edit.
 // icon-color: red; icon-glyph: briefcase-medical;
 
 /**
@@ -14,7 +17,7 @@
 
 // ============= EXTRA KONFIGURATION ============= ============= ===========
 
-const CONFIG_OPEN_URL = "https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4" // open RKI dashboard on tap, CONFIG_OPEN_URL=false to disable
+const CONFIG_OPEN_URL = false // open RKI dashboard on tap, CONFIG_OPEN_URL=false to disable
 const CONFIG_SHOW_AREA_ICON = true // show "Icon" before AreaName: Like KS = Kreisfreie Stadt, LK = Landkreis,...
 const CONFIG_GRAPH_SHOW_DAYS = 14
 const CONFIG_MAX_CACHED_DAYS = 14 // WARNING!!! Smaller values will delete saved days > CONFIG_MAX_CACHED_DAYS. Backup JSON first ;-)
@@ -226,7 +229,9 @@ function addIncidence(view, data, useStaticCoordsIndex = false, status = 200) {
 
     // === INCIDENCE
     let incidence = formatNumber(todayData.area.incidence.toFixed(1), 1)
-    if (todayData.area.incidence >= 100) incidence = formatNumber(Math.round(todayData.area.incidence))
+    if (!MEDIUMWIDGET) {
+        if (todayData.area.incidence >= 100) incidence = formatNumber(Math.round(todayData.area.incidence))
+    }
     addLabelTo(stackMainRow, incidence, Font.boldSystemFont(27), getIncidenceColor(todayData.area.incidence))
     
     if (yesterdayData) {
@@ -244,7 +249,9 @@ function addIncidence(view, data, useStaticCoordsIndex = false, status = 200) {
     incidenceBLStack.setPadding(2,3,2,3)
 
     let incidenceBL = formatNumber(todayData.state.incidence.toFixed(1), 1);
-    if (todayData.state.incidence >= 100) incidenceBL = formatNumber(Math.round(todayData.state.incidence))
+    if (!MEDIUMWIDGET) {
+        if (todayData.state.incidence >= 100) incidenceBL = formatNumber(Math.round(todayData.state.incidence))
+    }
     if (yesterdayData) {
         incidenceBL += getTrendArrow(todayData.state.incidence, yesterdayData.state.incidence)
     }

--- a/incidence.js
+++ b/incidence.js
@@ -1,9 +1,6 @@
 // Variables used by Scriptable.
 // These must be at the very top of the file. Do not edit.
 // icon-color: yellow; icon-glyph: file-medical-alt;
-// Variables used by Scriptable.
-// These must be at the very top of the file. Do not edit.
-// icon-color: red; icon-glyph: briefcase-medical;
 
 /**
  * Licence: Robert Koch-Institut (RKI), dl-de/by-2-0
@@ -17,7 +14,7 @@
 
 // ============= EXTRA KONFIGURATION ============= ============= ===========
 
-const CONFIG_OPEN_URL = false // open RKI dashboard on tap, CONFIG_OPEN_URL=false to disable
+const CONFIG_OPEN_URL = "https://experience.arcgis.com/experience/478220a4c454480e823b17327b2bf1d4" // open RKI dashboard on tap, CONFIG_OPEN_URL=false to disable
 const CONFIG_SHOW_AREA_ICON = true // show "Icon" before AreaName: Like KS = Kreisfreie Stadt, LK = Landkreis,...
 const CONFIG_GRAPH_SHOW_DAYS = 14
 const CONFIG_MAX_CACHED_DAYS = 14 // WARNING!!! Smaller values will delete saved days > CONFIG_MAX_CACHED_DAYS. Backup JSON first ;-)
@@ -229,8 +226,8 @@ function addIncidence(view, data, useStaticCoordsIndex = false, status = 200) {
 
     // === INCIDENCE
     let incidence = formatNumber(todayData.area.incidence.toFixed(1), 1)
-    if (!MEDIUMWIDGET) {
-        if (todayData.area.incidence >= 100) incidence = formatNumber(Math.round(todayData.area.incidence))
+    if (!MEDIUMWIDGET && todayData.area.incidence >= 100) {
+        incidence = formatNumber(Math.round(todayData.area.incidence))
     }
     addLabelTo(stackMainRow, incidence, Font.boldSystemFont(27), getIncidenceColor(todayData.area.incidence))
     
@@ -249,8 +246,8 @@ function addIncidence(view, data, useStaticCoordsIndex = false, status = 200) {
     incidenceBLStack.setPadding(2,3,2,3)
 
     let incidenceBL = formatNumber(todayData.state.incidence.toFixed(1), 1);
-    if (!MEDIUMWIDGET) {
-        if (todayData.state.incidence >= 100) incidenceBL = formatNumber(Math.round(todayData.state.incidence))
+    if (!MEDIUMWIDGET && todayData.state.incidence >= 100) {
+        incidenceBL = formatNumber(Math.round(todayData.state.incidence))
     }
     if (yesterdayData) {
         incidenceBL += getTrendArrow(todayData.state.incidence, yesterdayData.state.incidence)


### PR DESCRIPTION
DunkelDunkelRot bei 7 Tage Inzidenz > 200 eingefügt.
Siehe
https://www.lgl.bayern.de/gesundheit/infektionsschutz/infektionskrankheiten_a_z/coronavirus/karte_coronavirus/