### PR TITLE
[FIX] Replacing scriptSelfUpdate to be enabled after updating

### DIFF
--- a/incidence.js
+++ b/incidence.js
@@ -188,6 +188,7 @@ class IncidenceWidget {
             if (script !== '') {
                 if (cfm.fm.fileExists(filenameBak)) await cfm.fm.remove(filenameBak)
                 cfm.copy(ENV.script.filename, filenameBak)
+                script = script.replace("scriptSelfUpdate: false", "scriptSelfUpdate: true")
                 cfm.save(script, ENV.script.filename)
                 ENV.script.updateStatus = 'updated'
                 Helper.log('script selfUpdate', ENV.script.updateStatus);


### PR DESCRIPTION
When scriptSelfUpdate is enabled and the update occurs, it will disable the setting (since it is currently disabled per default). This PR replaces the default to keep self updated enabled.