### PR TITLE
Graph in `smallIncidenceRow` abgeschnitten.

### DIFF
--- a/incidence.js
+++ b/incidence.js
@@ -332,9 +332,9 @@ class UIComp {
         b4.space(2)
         let graphImg
         if (CFG.graphShowValues == 'i') {
-          graphImg = UI.generateIcidenceGraph(ENV.cache[cacheID], 56, 10, false).getImage()
+          graphImg = UI.generateIcidenceGraph(ENV.cache[cacheID], 58, 10, false).getImage()
         } else {
-          graphImg = UI.generateGraph(ENV.cache[cacheID], 56, 10, false).getImage()
+          graphImg = UI.generateGraph(ENV.cache[cacheID], 58, 10, false).getImage()
         }
         b4.image(graphImg, 0.9)
 


### PR DESCRIPTION
Der in 'UIComp.smallIncidenceRow' erzeugte Graph schneidet Balken des Graphs teilweise ab.
Durch die Änderung der Breite des Graphens von 56 auf 58 wird dieser Wert nicht mehr abgeschnitten.

Vorher:
![Bild mit abgeschnittenem Graph](https://user-images.githubusercontent.com/33345266/102931975-bad5e180-449f-11eb-8ef8-047d356019c5.PNG)

Nachher:
![Bild ohne abgeschnittenem Graph](https://user-images.githubusercontent.com/33345266/102931978-bb6e7800-449f-11eb-98db-bc3824ff8624.PNG)