### PR TITLE
Verbesserung für Graphen.

### DIFF
--- a/incidence.js
+++ b/incidence.js
@@ -377,6 +377,7 @@ class UI {
         let context = new DrawContext()
         context.size = new Size(width, height)
         context.opaque = false
+        context.respectScreenScale = true
         let max = Math.max.apply(Math, graphData.map(function (o) { return o.cases; }))
         max = (max <= 0) ? 10 : max;
         let w = Math.max(2, Math.round((width - (graphData.length * 2)) / graphData.length))
@@ -385,7 +386,7 @@ class UI {
             let item = graphData[i]
             let value = parseFloat(item.cases)
             if (value === -1 && i == 0) value = 10;
-            let h = Math.max(2, Math.round((Math.abs(value) / max) * height))
+            let h = Math.max(2, (Math.abs(value) / max) * height)
             let x = xOffset + (w + 1) * i
             let rect = new Rect(x, height - h, w, h)
             context.setFillColor(UI.getIncidenceColor((item.cases >= 1) ? item.incidence : 0))
@@ -398,6 +399,7 @@ class UI {
         let context = new DrawContext()
         context.size = new Size(width, height)
         context.opaque = false
+        context.respectScreenScale = true
         let max = Math.max.apply(Math, graphData.map(function (o) { return o.incidence; }))
         let min = Math.min.apply(Math, graphData.map(function (o) { return o.incidence; })) / 1.2
         max = (max <= 0) ? 10 : max - min;
@@ -407,7 +409,7 @@ class UI {
             let item = graphData[i]
             let value = parseFloat(item.incidence) - min
             if (value === -1 && i == 0) value = 10;
-            let h = Math.max(2, Math.round((Math.abs(value) / max) * (height - 1)))
+            let h = Math.max(2,(Math.abs(value) / max) * (height - 1))
             let x = xOffset + (w + 1) * i
             let rect = new Rect(x, height - h - 1, w, h)
             context.setFillColor(UI.getIncidenceColor((item.cases >= 1) ? item.incidence : 0))


### PR DESCRIPTION
Die Graphen werden aktuell teilweise etwas unscharf Dargestellt.

Durch das setzen der eigenschaft `respectScreenScale` einse `DrawContext` auf True lässt sich dies in Teieln.

Dazu aus der Dokumentation aus Scriptable:
> When respecting the screen scale is disabled, you may experience that your images looks blurry because essentially the size you have specified will be stretched when rendered on the screen.
> Default is false.

Dadurch sehen die Graphen nicht nur an sich schärfer aus, sondern es ist auch möglich genauere Werte ohne runden zu verwenden.

 --- | Aktuell | Änderung
------------ | ------------- | ---
Inzidnez| ![graph_incidenc_old](https://user-images.githubusercontent.com/33345266/102936644-d396c500-44a8-11eb-9aa0-88dd1189cbc7.PNG) | ![graph_incidenc_new](https://user-images.githubusercontent.com/33345266/102936662-d98ca600-44a8-11eb-97b4-40405ab01c78.PNG)
Fälle |  ![graph_cases_old](https://user-images.githubusercontent.com/33345266/102936856-3f792d80-44a9-11eb-8e8e-db85a46c7bd8.PNG) | ![graph_cases_new](https://user-images.githubusercontent.com/33345266/102936860-41db8780-44a9-11eb-9954-ff4ed36c59e3.PNG)